### PR TITLE
Fix injection problems with Windows users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jambdev/tsc-hooks",
-  "version": "1.0.6",
+  "version": "1.0.7-0",
   "description": "Add tsc compiler hooks to your TypeScript project",
   "main": "run.js",
   "repository": "https://github.com/JambDev/tsc-hooks.git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tsc-hooks",
+  "name": "@jambdev/tsc-hooks",
   "version": "1.0.6",
   "description": "Add tsc compiler hooks to your TypeScript project",
   "main": "run.js",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "glob": "^7.1.7",
+    "glob-parent": "^6.0.0",
     "json5": "^2.2.0",
     "typescript": "^4.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.6",
   "description": "Add tsc compiler hooks to your TypeScript project",
   "main": "run.js",
-  "repository": "https://github.com/swimauger/tsc-hooks.git",
+  "repository": "https://github.com/JambDev/tsc-hooks.git",
   "author": "Mark Auger",
   "license": "Apache-2.0",
   "private": false,

--- a/run.js
+++ b/run.js
@@ -1,4 +1,4 @@
 const path = require('path');
 const script = require(path.resolve(__dirname, 'scripts', process.argv[2]));
 
-script(path.resolve(process.cwd(), (path.dirname(__dirname).endsWith("node_modules") ? '../' : 'node_modules/') + 'typescript/bin/tsc'));
+script(path.resolve(process.cwd(), '../typescript/bin/tsc'));

--- a/run.js
+++ b/run.js
@@ -1,4 +1,4 @@
 const path = require('path');
 const script = require(path.resolve(__dirname, 'scripts', process.argv[2]));
 
-script(path.resolve(process.cwd(), '../typescript/bin/tsc'));
+script(path.resolve(process.cwd(), (path.dirname(__dirname).endsWith("node_modules") ? '../' : 'node_modules/') + 'typescript/bin/tsc'));

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -6,7 +6,7 @@ module.exports = (TSC_BIN_PATH) => {
 
   const script = [
     '#!/usr/bin/env node',
-    `require('${path.relative(path.dirname(TSC_BIN_PATH), INJECTION_PATH)}')`,
+    `require('${JSON.stringify(path.relative(path.dirname(TSC_BIN_PATH), INJECTION_PATH))}')`,
     "require('../lib/tsc.js')"
   ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,6 +25,13 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+glob-parent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.0.tgz#f851b59b388e788f3a44d63fab50382b2859c33c"
+  integrity sha512-Hdd4287VEJcZXUwv1l8a+vXC1GjOQqXe+VS30w/ypihpcnu9M1n3xeYeJu5CBpeEQj2nAab2xxz28GuA3vp4Ww==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob@^7.1.7:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
@@ -49,6 +56,18 @@ inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+
+is-glob@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
 
 json5@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Make use of JSON.stringify to avoid issues with Windows' backslash path delimiter.