### PR TITLE
(re) Escape paths for Windows users

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -6,7 +6,7 @@ module.exports = (TSC_BIN_PATH) => {
 
   const script = [
     '#!/usr/bin/env node',
-    `require('${path.relative(path.dirname(TSC_BIN_PATH), INJECTION_PATH)}')`,
+    `require(${JSON.stringify(path.relative(path.dirname(TSC_BIN_PATH), INJECTION_PATH))})`,
     "require('../lib/tsc.js')"
   ];
 


### PR DESCRIPTION
Directly appending the backslash into JavaScript (and most programming languages) causes conflict as the backslash is used for representing other characters. We can solve this by using `JSON.stringify` which is already designed to escape strings for JavaScript. 