### PR TITLE
Issues/7 - Add allowTS option in compilerOptions

### DIFF
--- a/hooks/copy-files.js
+++ b/hooks/copy-files.js
@@ -10,7 +10,7 @@ module.exports = (tsconfig, tsconfigPath) => {
 
     const files = include?.reduce((files, file) => glob.sync(file, { ignore }), []) || [];
     for (const file of files) {
-      if (file.endsWith('.js') || file.endsWith('.ts')) continue;
+      if (file.endsWith('.js') || (!tsconfig.compilerOptions?.allowTS && file.endsWith('.ts'))) continue;
 
       const relative = file.replace(path.resolve(file, path.relative(file, tsconfigDir)), '').split('/').splice(2).join('/');
       const target = path.resolve(tsconfigDir, tsconfig.compilerOptions.outDir, relative);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsc-hooks",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Add tsc compiler hooks to your TypeScript project",
   "main": "run.js",
   "repository": "https://github.com/swimauger/tsc-hooks.git",


### PR DESCRIPTION
- [X] Fixes issue https://github.com/swimauger/tsc-hooks/issues/7
- Adds an `allowTS` option for copying TypeScript files into the out directory via the `copy-files` hook