### PR TITLE
🐛 Fix copying of `.tsx` files

### DIFF
--- a/hooks/copy-files/copy-files.hook.js
+++ b/hooks/copy-files/copy-files.hook.js
@@ -50,7 +50,7 @@ module.exports = {
       const outFile = outDir ? file.replace(rootRegex, outDir) : file;
       if (fs.lstatSync(file).isDirectory()) {
         fs.mkdirSync(outFile, { recursive: true });
-      } else if (!file.endsWith('js') || !(file.endsWith('ts') && !api.tsconfig?.compilerOptions?.allowTs)) {
+      } else if (!file.endsWith('js') || !((file.endsWith('ts') || file.endsWith('tsx')) && !api.tsconfig?.compilerOptions?.allowTs)) {
         fs.copyFileSync(file, outFile);
       }
     }


### PR DESCRIPTION
## Edited Library
- [ ✔️ ] Passes tests
- [ ✔️ ] Used gitmoji for commits

**Description of Edits**
Currently, `copy-files` copies `.tsx` files even when `allowTs: true`. 

This fixes the problem by adding an additional check for `.tsx` files when deciding whether or not to copy.
