### PR TITLE
Allow typescript v5 and move it to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,14 @@
     "clean:tests": "docker rmi tsc-hooks-test --force"
   },
   "dependencies": {
-    "json5": "^2.2.0",
-    "typescript": "^4.3.2"
+    "json5": "^2.2.0"
   },
   "devDependencies": {
     "chalk": "^4.1.2",
-    "glob": "^7.1.7"
+    "glob": "^7.1.7",
+    "typescript": "^4.3.2 || ^5.0.2 "
+  },
+  "peerDependencies": {
+    "typescript": "^4.3.2 || ^5.0.2 "
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,10 +120,10 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-typescript@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+"typescript@^4.3.2 || ^5.0.2 ":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
1. allow typescript v5
2. move TypeScript as peer dependency as suggested in this comment: https://github.com/swimauger/tsc-hooks/pull/21#issuecomment-916310183